### PR TITLE
Name ui-views on index.html for multiple insetions per state

### DIFF
--- a/app/home/home.module.js
+++ b/app/home/home.module.js
@@ -5,7 +5,14 @@ angular.module('home', [])
     $stateProvider
     .state('home', {
       url: '/home',
-      templateUrl: 'home.template.html'
+      views: {
+        'title': {
+          template: 'Home'
+        },
+        'content-body': {
+          templateUrl: 'home.template.html',
+        }
+      }
     });
   },
 ]);

--- a/app/index.html
+++ b/app/index.html
@@ -14,7 +14,7 @@
   <section class="site-container">
     <nav class="breadcrumbs">
       <span class="breadcrumbs__item">Adobe Marketing Cloud</span>
-      <span class="breadcrumbs__item">Weather</span>
+      <span class="breadcrumbs__item" ui-view="title"></span>
     </nav>
     <section class="site-body">
       <nav class="sidebar">
@@ -23,9 +23,9 @@
         <a ui-sref="weather" class="sidebar__item"><div>Weather</div></a>
       </nav>
       <section class="content">
-        <header class="content-header">Weather</header>
+        <header class="content-header" ui-view="title"></header>
         <section class="content-body">
-          <div ui-view></div>
+          <div ui-view="content-body"></div>
         </section>
         <footer class="content-footer">&copy; 2016 Adobe Systems Incorporated. All Rights Reserved.</footer>
       </section>

--- a/app/weather/weather.module.js
+++ b/app/weather/weather.module.js
@@ -5,7 +5,14 @@ angular.module('weather', [])
     $stateProvider
     .state('weather', {
       url: '/weather',
-      templateUrl: 'weather.template.html'
+      views: {
+        'title': {
+          template: 'Weather'
+        },
+        'content-body': {
+          templateUrl: 'weather.template.html',
+        }
+      },
     });
   },
 ]);


### PR DESCRIPTION
- Use the 'views' parameter of `$stateProvider.state()` to populate dynamic content in two areas:
  - Breadcrumbs and content-header reflect the name of the state through the `title` param
  - Content-body is populated by the module's template file through the `content-body` param